### PR TITLE
Add 'StatusNone' for dns error

### DIFF
--- a/protocol/status.go
+++ b/protocol/status.go
@@ -116,6 +116,9 @@ const (
 	// StatusDSNoSEP the corresponding public key (DNSKEY) isn't a secure entry
 	// point
 	StatusDSNoSEP Status = "ds nosep"
+
+	// StatusNONE dns error has occurred
+	StatusNone Status = "plain dns error"
 )
 
 // Proposed by NIC.br for domain status


### PR DESCRIPTION
RDAP server should display a ds status in cases where there is dns error.