### PR TITLE
Removendo campo 'Port43' da estrutura do 'Help'

### DIFF
--- a/protocol/help.go
+++ b/protocol/help.go
@@ -5,5 +5,4 @@ type Help struct {
 	Notices []Notice `json:"notices,omitempty"`
 	Lang    string   `json:"lang,omitempty"`
 	Conformance
-	Port43
 }


### PR DESCRIPTION
Port43 não faz parte dos campos esperados no help.