### PR TITLE
Fix: Examples didn't follow the correct naming convention

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -1122,7 +1122,7 @@ func ExampleClient() {
 	fmt.Println(string(output))
 }
 
-func ExampleBootstrapClient() {
+func ExampleClient_bootstrap() {
 	c := NewClient(nil)
 
 	ipnetwork, _, err := c.Query("214.1.2.3", nil, nil)
@@ -1140,7 +1140,7 @@ func ExampleBootstrapClient() {
 	fmt.Println(string(output))
 }
 
-func ExampleAdvancedBootstrapClient() {
+func ExampleClient_aAdvancedBootstrap() {
 	var httpClient http.Client
 
 	cacheDetector := CacheDetector(func(resp *http.Response) bool {


### PR DESCRIPTION
```
$ go test ./...
./client_test.go:1125:1: ExampleBootstrapClient refers to unknown identifier: BootstrapClient
./client_test.go:1143:1: ExampleAdvancedBootstrapClient refers to unknown identifier: AdvancedBootstrapClient
FAIL	github.com/registrobr/rdap [build failed]
ok  	github.com/registrobr/rdap/protocol	0.627s
FAIL
```

https://pkg.go.dev/testing#hdr-Examples